### PR TITLE
Update policy based on feedback

### DIFF
--- a/policy/delegations.md
+++ b/policy/delegations.md
@@ -208,6 +208,8 @@ Points are decided by the SubDAO.
 
 This criterion is separate from the minimum governance voting participation outlined in section 2.1.7
 
+### 2.3.3 NOT USED
+
 ### 2.3.4 Self-bonded token (Max. 500 points)
 
 Points are awarded for a validator's self-stake compared to the total amount staked to the validator. The minimum required self-stake is 0.1% of the total staked and 500 JUNO to be eligible for this criteria.

--- a/policy/delegations.md
+++ b/policy/delegations.md
@@ -200,19 +200,13 @@ Some examples of these activities are provided below:
 
 - Publish valuable content online (Medium, Twitter threads, etc) that highlights Juno and Applications on the Juno Network.
 
-### 2.3.2 Active participation in governance (Max. 1000 points)
+### 2.3.2 Active participation in governance (Max. 1500 points)
 
 Points are awarded for active participation in governance including taking part in discussions on commonwealth.im both before a proposal goes on-chain and during the voting period.
 
 Points are decided by the SubDAO.
 
 This criterion is separate from the minimum governance voting participation outlined in section 2.1.7
-
-### 2.3.3 Commission re-staking (Max. 500 points)
-
-Points are awarded for the portion of validator rewards that are re-staked to the validator during the previous epoch.
-
-$$ points = \frac {commission\ re-staked}{commission\ received} * 1,000 , max\ 500$$
 
 ### 2.3.4 Self-bonded token (Max. 500 points)
 


### PR DESCRIPTION
Based on feedback, we're removing the "Restake" criteria and moving the allocated points to "Active participation in governance"